### PR TITLE
Convert to a module, don't truncate and hexdump stacktrace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/lytics/squaredance
+
+go 1.21.3

--- a/squaredance.go
+++ b/squaredance.go
@@ -3,7 +3,7 @@ package squaredance
 
 import (
 	"fmt"
-	"runtime"
+	"runtime/debug"
 	"sync"
 )
 
@@ -35,7 +35,7 @@ func IsPanic(e error) bool {
 type PanicError struct {
 	// Value returned from recover()
 	Panic interface{}
-	Stack []byte
+	Stack string
 }
 
 func (p *PanicError) Error() string {
@@ -67,11 +67,7 @@ func (t *caller) Spawn(sf func(Follower) error) {
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
-				p := &PanicError{r, make([]byte, 100000)}
-				wrote := runtime.Stack(p.Stack, false)
-				if wrote < 100000 {
-					p.Stack = p.Stack[:wrote]
-				}
+				p := &PanicError{r, string(debug.Stack())}
 				t.setError(p)
 			}
 			t.childwg.Done()


### PR DESCRIPTION
- Make it a module
- Fix caught errors being returned as truncated hex bytes